### PR TITLE
Make work with PHP 8.1 (strftime deprecation)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - 7.3
     - 7.4
     - 8.0
+    - 8.1
 
 before_install:
   # turn off XDebug

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "econea/nusoap",
   "type": "library",
-  "description": "Fixed NuSOAP for PHP 5.4 - 8.0",
+  "description": "Fixed NuSOAP for PHP 5.4 - 8.1",
   "keywords": ["soap","nusoap","php","http","xml","transport","client"],
   "license": "LGPL-2.0-only",
   "homepage": "https://github.com/pwnlabs/nusoap",

--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-$Id: nusoap.php,v 1.123 2010/04/26 20:15:08 snichol Exp $
+$Id: nusoap.php,v 1.124 2010/04/26 20:15:08 snichol Exp $
 
 NuSOAP - Web Services Toolkit for PHP
 
@@ -895,7 +895,9 @@ class nusoap_base
             $sec = time();
             $usec = 0;
         }
-        return strftime('%Y-%m-%d %H:%M:%S', $sec) . '.' . sprintf('%06d', $usec);
+        $dtx = new DateTime("@$sec"); 
+	return
+          date_format($dtx, 'Y-m-d H:i:s') . '.' . sprintf('%06d', $usec);
     }
 
     /**


### PR DESCRIPTION
PHP 8.1 deprecates strftime. Nusoap uses that. This pull request removes the use of strftime, and replaces it with what should be its functional equivalent. 