### PR TITLE
`mb_convert_encoding` support

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -7141,7 +7141,7 @@ class nusoap_parser extends nusoap_base
             // raw UTF-8 that, e.g., might not map to iso-8859-1
             // TODO: this can also be handled with xml_parser_set_option($this->parser, XML_OPTION_TARGET_ENCODING, "ISO-8859-1");
             if ($this->decode_utf8) {
-                $data = utf8_decode($data);
+                $data = function_exists('mb_convert_encoding') ? mb_convert_encoding($data, 'ISO-8859-1', 'UTF-8') : utf8_decode($data);
             }
         }
         $this->message[$pos]['cdata'] .= $data;


### PR DESCRIPTION
On PHP 8.2 utf8_decode is going to be deprecated, maybe we can start changing that
https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated
https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated#utf8_decode-mbstring
![image](https://user-images.githubusercontent.com/4933954/174193177-df2b7d7f-5331-4ee1-be9b-8df6266cd4e2.png)
