### PR TITLE
$this->methodreturn can be array

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4224,7 +4224,7 @@ class nusoap_server extends nusoap_base
     {
         $this->debug('Entering serialize_return methodname: ' . $this->methodname . ' methodURI: ' . $this->methodURI);
         // if fault
-        if (isset($this->methodreturn) && ((get_class($this->methodreturn) == 'soap_fault') || (get_class($this->methodreturn) == 'nusoap_fault'))) {
+        if (isset($this->methodreturn) && is_object($this->methodreturn) && ((get_class($this->methodreturn) == 'soap_fault') || (get_class($this->methodreturn) == 'nusoap_fault'))) {
             $this->debug('got a fault object from method');
             $this->fault = $this->methodreturn;
             return;


### PR DESCRIPTION
In function serialize_return, $this->methodreturn can be an array, resulting in "PHP Warning: get_class() expects parameter 1 to be object, array given" Above code change fixes this by checking for object. However, without knowing the complete flow, I am unsure if there is an underlying issue which assigns incorrect type to $this->methodreturn.