### PR TITLE
Add skippable proxy header

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -2821,7 +2821,9 @@ class soap_transport_http extends nusoap_base
             'HTTP/1.0 401',
             'HTTP/1.1 401',
             'HTTP/1.0 200 Connection established',
-            'HTTP/1.1 200 Connection established');
+            'HTTP/1.0 200 Connection Established',
+            'HTTP/1.1 200 Connection established',
+            'HTTP/1.1 200 Connection Established');
         foreach ($skipHeaders as $hd) {
             $prefix = substr($data, 0, strlen($hd));
             if ($prefix == $hd) {


### PR DESCRIPTION
Adding two "skippable" headers with title casing.

I ran into this problem when using Apache as a forward proxy. It fixes the issue when trying to parse the XML but not all of the HTTP headers have been stripped, and you end up with this error:
```
wsdl: XML error parsing WSDL from https://soap.acme.org?WSDL on line 1: Not well-formed (invalid token)
```