### PR TITLE
fix - undefined array key boundaryStr and passing null to stripos

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -6843,7 +6843,7 @@ class nusoap_parser extends nusoap_base
                 $substrXml = $xml;
                 foreach($this->attachments as $key => $attachment) {
                     $startPos = max(
-                        stripos($substrXml, $attachment['boundaryStr']),
+                        isset($attachment['boundaryStr']) ? stripos($substrXml, $attachment['boundaryStr']) : false,
                         (array_key_exists('Content-Type', $attachment) ? stripos($substrXml, $attachment['Content-Type']) : 0),
                         (array_key_exists('Content-Id', $attachment) ? stripos($substrXml, $attachment['Content-Id']) : 0),
                         (array_key_exists('Content-Transfer-Encoding', $attachment) ? stripos($substrXml, $attachment['Content-Transfer-Encoding']) : 0)


### PR DESCRIPTION
- solved warning of undefined array key $attachment['boundaryStr']
- solved deprecated passing null to stripos (thanks to undefined key of array)
- if key is undefined return false - same return value as stripos do not find boundary string in XML string