### PR TITLE
fix - array to string conversion warning

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -6068,7 +6068,7 @@ class wsdl extends nusoap_base
             }
             $attrs = $value->attributes;
             $value = $value->value;
-            $this->debug("in serializeType: soapval overrides value to $value");
+            $this->debug("in serializeType: soapval overrides value to " . $this->varDump($value));
             if ($attrs) {
                 if (!is_array($value)) {
                     $value['!'] = $value;


### PR DESCRIPTION
Fix for PHP Warning: Array to string conversion in nusoap.php on line 6069